### PR TITLE
Update xbmc.translatePath to xbmcvfs.translatePath.

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.cache" name="cache" version="1.0.4" provider-name="fraser">
+<addon id="script.module.cache" name="cache" version="1.0.5" provider-name="fraser">
     <extension point="xbmc.python.module" library="lib"/>
     <extension point="xbmc.addon.metadata">
         <summary lang="en_GB">Simple HTTP Cache using sqlite3</summary>
@@ -11,6 +11,7 @@ Can be used as a generic key/blob data store when used without directives
         <platform>all</platform>
         <email>fraser.chapman@gmail.com</email>
         <source>https://github.com/FraserChapman/script.module.cache</source>
+        <news>v1.0.5 (14-7-24) - "Update xbmc.translatePath to xbmcvfs.translatePath.</news>
         <news>v1.0.3 (18-7-19) - Fixes python version error</news>
     </extension>
 </addon>

--- a/lib/cache.py
+++ b/lib/cache.py
@@ -10,7 +10,6 @@ import time
 from datetime import datetime, timedelta, tzinfo
 from os import path
 
-import xbmc
 import xbmcaddon
 import xbmcvfs
 
@@ -24,7 +23,7 @@ logger = logging.getLogger(__name__)
 HTTP_DATE_FORMAT = "%a, %d %b %Y %H:%M:%S %Z"
 ADDON = xbmcaddon.Addon()
 ADDON_PROFILE = ADDON.getAddonInfo("profile").encode("utf-8").decode("utf-8")
-CACHE_URI = xbmc.translatePath(path.join(ADDON_PROFILE, "cache.sqlite"))
+CACHE_URI = xbmcvfs.translatePath(path.join(ADDON_PROFILE, "cache.sqlite"))
 
 
 def httpdate_to_datetime(input_date):


### PR DESCRIPTION
xbmc.translatePath to xbmcvfs.translatePath.
The function is deprecated in kodi 19 or higther.